### PR TITLE
WTF Java9: Graphics bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ So far we have trouble with...
 * [the Maven JAXB2 Plugin](maven-jaxb2-plugin)
 * [Noto Sans](noto-sans)
 * [XML transformations](xml-transformer)
+* [Graphics bounds](graphics-bounds)
 
 
 ## Observe!

--- a/graphics-bounds/README.md
+++ b/graphics-bounds/README.md
@@ -1,0 +1,15 @@
+# Graphics bounds are no longer real
+
+Bounds obtained from the graphics device configuration created from a BufferedImage are no longer real.
+Starting from Java 9, they always return (0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE), which are very huge bounds!
+
+```java
+System.out.println(new BufferedImage(800, 600, BufferedImage.TYPE_3BYTE_BGR).createGraphics().getDeviceConfiguration().getBounds());
+```
+
+[The test](src/test/java/wtf/java9/graphics_bounds/GraphicsBoundsTest.java) shows how Java 8 has expected behaviour while Java 9 surprises us.
+
+(Last checked: 8u152 and 9.0.1)
+
+The JDK-issue ([JDK-8072682](https://bugs.openjdk.java.net/browse/JDK-8072682) and the [associated commit](http://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/aafc0a279f95) show this is intentional.
+Yet we can seriously question the solution applied to the cache problem described in the bug report.

--- a/graphics-bounds/meta.yaml
+++ b/graphics-bounds/meta.yaml
@@ -1,0 +1,2 @@
+title: Graphics bounds are no longer real
+date: 2017-11-20

--- a/graphics-bounds/pom.xml
+++ b/graphics-bounds/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>wtf.java9</groupId>
+	<artifactId>graphics-bounds</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<parent>
+		<groupId>wtf.java9</groupId>
+		<artifactId>seriously-wtf</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<profiles>
+		<!-- JAVA 9 -->
+		<profile>
+			<id>java-9</id>
+			<activation>
+				<jdk>9</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<source>9</source>
+							<target>9</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+</project>

--- a/graphics-bounds/src/main/java/wtf/java9/graphics_bounds/GraphicsBounds.java
+++ b/graphics-bounds/src/main/java/wtf/java9/graphics_bounds/GraphicsBounds.java
@@ -1,0 +1,20 @@
+package wtf.java9.graphics_bounds;
+
+import java.awt.*;
+import java.awt.image.*;
+import java.lang.reflect.Constructor;
+
+public class GraphicsBounds {
+
+	public static void main(String[] args) {
+		System.out.println(createBounds());
+	}
+
+	/**
+	 * Should return 800x600, right?
+	 */
+	public static Rectangle createBounds() {
+		return new BufferedImage(800, 600, BufferedImage.TYPE_3BYTE_BGR)
+			.createGraphics().getDeviceConfiguration().getBounds();
+	}
+}

--- a/graphics-bounds/src/test/java/wtf/java9/graphics_bounds/GraphicsBoundsTest.java
+++ b/graphics-bounds/src/test/java/wtf/java9/graphics_bounds/GraphicsBoundsTest.java
@@ -1,0 +1,16 @@
+package wtf.java9.graphics_bounds;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+
+class GraphicsBoundsTest {
+
+	@Test
+	void createBounds() throws Exception {
+		Assertions.assertEquals(
+				new Rectangle(0, 0, 800, 600),
+				GraphicsBounds.createBounds());
+	}
+}


### PR DESCRIPTION
Bounds obtained from the graphics device configuration created from a BufferedImage are no longer real.
Starting from Java 9, they always return (0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE), which are very huge bounds!

This causes a freeze in our application: https://josm.openstreetmap.de/ticket/15535#comment:29